### PR TITLE
Changed so worksheet examples actually compile.

### DIFF
--- a/api-examples-to-merge/worksheet.md
+++ b/api-examples-to-merge/worksheet.md
@@ -8,7 +8,6 @@ Excel.run(function (ctx) {
 	var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
 	worksheet.activate();
 	return ctx.sync(); 
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -25,7 +24,6 @@ Excel.run(function (ctx) {
 	var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
 	worksheet.delete();
 	return ctx.sync(); 
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -45,7 +43,6 @@ Excel.run(function (ctx) {
 	cell.load('address');
 	return ctx.sync().then(function() {
 		console.log(cell.address);
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -148,4 +145,3 @@ Excel.run(function (ctx) {
 		}
 });
 ```
-


### PR DESCRIPTION
Worksheet example had extra brackets in it - found when doing a syntax check. Not checked for logic/correctness by me, but checked for syntax at least. 
