### PR TITLE
Fixing Code Samples for Syntax Errors

### DIFF
--- a/api-examples-to-merge/table.md
+++ b/api-examples-to-merge/table.md
@@ -67,6 +67,7 @@ Excel.run(function (ctx) {
 ### getRange()
 ```js
 Excel.run(function (ctx) { 
+	var tableName = 'Table1';
 	var table = ctx.workbook.tables.getItem(tableName);
 	var tableRange = table.getRange();
 	tableRange.load('address');	
@@ -125,9 +126,9 @@ Get a table by index.
 Excel.run(function (ctx) { 
 	var index = 0;
 	var table = ctx.workbook.tables.getItemAt(0);
-	table.name('name')
+	table.load('id')
 	return ctx.sync().then(function() {
-			console.log(table.name);
+			console.log(table.id);
 	});
 }).catch(function(error) {
 		console.log("Error: " + error);
@@ -145,10 +146,10 @@ Excel.run(function (ctx) {
 	var table = ctx.workbook.tables.getItem(tableName);
 	table.name = 'Table1-Renamed';
 	table.showTotals = false;
-	table.tableStyle = 'TableStyleMedium2';
+	table.style = 'TableStyleMedium2';
 	table.load('tableStyle');
 	return ctx.sync().then(function() {
-			console.log(table.tableStyle);
+			console.log(table.style);
 	});
 }).catch(function(error) {
 		console.log("Error: " + error);

--- a/api-examples-to-merge/tablecollection.md
+++ b/api-examples-to-merge/tablecollection.md
@@ -22,8 +22,9 @@ Excel.run(function (ctx) {
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
 	var table = ctx.workbook.tables.getItem(tableName);
+	table.load('name');
 	return ctx.sync().then(function() {
-			console.log(table.index);
+			console.log(table.name);
 	});
 }).catch(function(error) {
 		console.log("Error: " + error);
@@ -38,6 +39,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var table = ctx.workbook.tables.getItemAt(0);
+	table.load('name');
 	return ctx.sync().then(function() {
 			console.log(table.name);
 	});
@@ -54,7 +56,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tables = ctx.workbook.tables;
-	tables.load('items');
+	tables.load();
 	return ctx.sync().then(function() {
 		console.log("tables Count: " + tables.count);
 		for (var i = 0; i < tables.items.length; i++)

--- a/api-examples-to-merge/tablecolumn.md
+++ b/api-examples-to-merge/tablecolumn.md
@@ -4,7 +4,7 @@
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var column = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(2);
+	var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
 	column.delete();
 	return ctx.sync(); 
 }).catch(function(error) {
@@ -20,7 +20,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var column = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(0);
+	var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
 	var dataBodyRange = column.getDataBodyRange();
 	dataBodyRange.load('address');
 	return ctx.sync().then(function() {
@@ -38,7 +38,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var columns = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(0);
+	var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
 	var headerRowRange = columns.getHeaderRowRange();
 	headerRowRange.load('address');
 	return ctx.sync().then(function() {
@@ -56,7 +56,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var columns = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(0);
+	var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
 	var columnRange = columns.getRange();
 	columnRange.load('address');
 	return ctx.sync().then(function() {
@@ -75,7 +75,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var columns = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(0);
+	var columns = ctx.workbook.tables.getItem(tableName).columns.getItemAt(0);
 	var totalRowRange = columns.getTotalRowRange();
 	totalRowRange.load('address');
 	return ctx.sync().then(function() {
@@ -94,7 +94,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var column = ctx.workbook.tables.getItem(tableName).tableColumns.getItem(0);
+	var column = ctx.workbook.tables.getItem(tableName).columns.getItem(0);
 	column.load('index');
 	return ctx.sync().then(function() {
 		console.log(column.index);
@@ -109,9 +109,10 @@ Excel.run(function (ctx) {
 
 ```js
 Excel.run(function (ctx) { 
+	var tableName = 'Table1';
 	var tables = ctx.workbook.tables;
 	var newValues = [["New"], ["Values"], ["For"], ["New"], ["Column"]];
-	var column = ctx.workbook.tables.getItem(tableName).tableColumns.getItemAt(2);
+	var column = ctx.workbook.tables.getItem(tableName).columns.getItemAt(2);
 	column.values = newValues;
 	column.load('values');
 	return ctx.sync().then(function() {

--- a/api-examples-to-merge/tablecolumncollection.md
+++ b/api-examples-to-merge/tablecolumncollection.md
@@ -23,7 +23,7 @@ Excel.run(function (ctx) {
 
 ```js
 Excel.run(function (ctx) { 
-	var tablecolumn = ctx.workbook.tables.getItem['Table1'].columns.getItem(0);
+	var tablecolumn = ctx.workbook.tables.getItem('Table1').columns.getItem(0);
 	tablecolumn.load('name');
 	return ctx.sync().then(function() {
 			console.log(tablecolumn.name);
@@ -55,7 +55,7 @@ Excel.run(function (ctx) {
 
 ```js
 Excel.run(function (ctx) { 
-	var tablecolumns = ctx.workbook.tables.getItem['Table1'].columns;
+	var tablecolumns = ctx.workbook.tables.getItem('Table1').columns;
 	tablecolumns.load('items');
 	return ctx.sync().then(function() {
 		console.log("tablecolumns Count: " + tablecolumns.count);

--- a/api-examples-to-merge/tablerow.md
+++ b/api-examples-to-merge/tablerow.md
@@ -4,10 +4,9 @@
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var row = ctx.workbook.tables.getItem(tableName).tableRows.getItemAt(2);
+	var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
 	row.delete();
 	return ctx.sync(); 
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -21,7 +20,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var row = ctx.workbook.tables.getItem(tableName).tableRows.getItemAt(0);
+	var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(0);
 	var rowRange = row.getRange();
 	rowRange.load('address');
 	return ctx.sync().then(function() {
@@ -40,7 +39,7 @@ Excel.run(function (ctx) {
 ```js
 Excel.run(function (ctx) { 
 	var tableName = 'Table1';
-	var row = ctx.workbook.tables.getItem(tableName).tableRows.getItem(0);
+	var row = ctx.workbook.tables.getItem(tableName).rows.getItem(0);
 	row.load('index');
 	return ctx.sync().then(function() {
 		console.log(row.index);
@@ -57,7 +56,8 @@ Excel.run(function (ctx) {
 Excel.run(function (ctx) { 
 	var tables = ctx.workbook.tables;
 	var newValues = [["New", "Values", "For", "New", "Row"]];
-	var row = ctx.workbook.tables.getItem(tableName).tableRows.getItemAt(2);
+    var tableName = 'Table1';
+	var row = ctx.workbook.tables.getItem(tableName).rows.getItemAt(2);
 	row.values = newValues;
 	row.load('values');
 	return ctx.sync().then(function() {

--- a/api-examples-to-merge/worksheet.md
+++ b/api-examples-to-merge/worksheet.md
@@ -8,7 +8,6 @@ Excel.run(function (ctx) {
 	var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
 	worksheet.activate();
 	return ctx.sync(); 
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -25,7 +24,6 @@ Excel.run(function (ctx) {
 	var worksheet = ctx.workbook.worksheets.getItem(wSheetName);
 	worksheet.delete();
 	return ctx.sync(); 
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -45,7 +43,6 @@ Excel.run(function (ctx) {
 	cell.load('address');
 	return ctx.sync().then(function() {
 		console.log(cell.address);
-	});
 }).catch(function(error) {
 		console.log("Error: " + error);
 		if (error instanceof OfficeExtension.Error) {
@@ -148,4 +145,3 @@ Excel.run(function (ctx) {
 		}
 });
 ```
-


### PR DESCRIPTION
Table examples are incorrect - fixed several of them as some were missing tableName as a variable, called the wrong thing for row & column, or incorrectly referenced id.
